### PR TITLE
673: Fix default api_key command

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -797,7 +797,7 @@ jupyter lab --AiExtension.default_embeddings_model=bedrock:amazon.titan-embed-te
 
 Specify default API keys
 ```bash
-jupyter lab --AiExtension.default_api_keys={'OPENAI_API_KEY': 'sk-abcd'}
+jupyter lab --AiExtension.default_api_keys='{'OPENAI_API_KEY': 'sk-abcd'}'
 ```
 
 


### PR DESCRIPTION
Small change to fix https://github.com/jupyterlab/jupyter-ai/issues/673